### PR TITLE
Reduced escaping and use multiline

### DIFF
--- a/vars/archiveArtifacts.groovy
+++ b/vars/archiveArtifacts.groovy
@@ -33,10 +33,19 @@ def call(Map args) {
                             returnStdout: true).trim()
     }
 
-    if (uploadedUrl =~ /https\:\/\//) {
+    if (uploadedUrl =~ 'https://') {
         /* if the output was a URL, generate our redirect file */
         String redirectFile = "${args.artifacts}.html"
-        String redirectHtml = "<html><head><meta http-equiv=\"refresh\" content=\"0;URL=${uploadedUrl}\" /><title>Redirecting...</title></head><body><center>${args.artifacts} can be downloaded <a href=\"${uploadedUrl}\">from Azure</a></center></body></html>"
+        String redirectHtml = """<!DOCTYPE html>
+          <html>
+          <head>
+            <meta http-equiv="refresh" content="0;URL=${uploadedUrl}" />
+            <title>Redirecting...</title>
+          </head>
+          <body>
+            <center>${args.artifacts} can be downloaded <a href="${uploadedUrl}">from Azure</a></center>
+          </body>
+          </html>"""
         writeFile file: redirectFile, text:redirectHtml
         steps.archiveArtifacts redirectFile
     }


### PR DESCRIPTION
Groovy doesn't need slashy strings to do matching.
Triple-quoted multiline string makes for easier reading and less escaping.